### PR TITLE
sortition: use binary search instead of loop

### DIFF
--- a/sortition.cpp
+++ b/sortition.cpp
@@ -9,14 +9,25 @@
 
 uint64_t sortition_binomial_cdf_walk(double n, double p, double ratio, uint64_t money) {
   boost::math::binomial_distribution<double> dist(n, p);
-  for (uint64_t j = 0; j < money; j++) {
-    // Get the cdf
-    double boundary = cdf(dist, j);
+  // Binary search for find the lowest stake <= cdf
+  uint64_t low = 0;
+  uint64_t high = money - 1;
+  while (low + 1 < high) {
+    const uint64_t mid = low + (high - low) / 2;
 
-    // Found the correct boundary, break
-    if (ratio <= boundary) {
-      return j;
+    // Get the cdf
+    if (ratio <= cdf(dist, mid)) {
+      high = mid;
+    } else {
+      low = mid + 1;
     }
+  }
+  // Found the correct boundary
+  if (ratio <= cdf(dist, low)) {
+    return low;
+  }
+  if (ratio <= cdf(dist, high)) {
+    return high;
   }
   return money;
 }


### PR DESCRIPTION
Instead of looping thorough whole `money`, better approach will be to use binary search to find correct value  